### PR TITLE
Init a elastic stack, creating an index mapping for the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.DS_Store
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: destroy
+destroy:
+	docker-compose -f docker/docker-compose.yml down
+	docker volume prune
+
+.PHONY: start
+start:
+	./scripts/init-elasticsearch.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,67 @@
+# **docker-compose-elasticsearch-kibana**
+
+# **Overview**
+Docker Compose for 3 Node Elasticsearch (7.3.0) Cluster and Kibana (7.3.0) Instance for development purposes.
+
+- [x] 3 Node Elasticsearch version 7.3.0
+- [x] Kibana version 7.3.0
+- [x] Audit Beat version 7.3.0
+- [x] Metric Beat version 7.3.0
+- [x] Heart Beat version 7.3.0
+- [x] Packet Beat version 7.3.0
+- [x] File Beat version 7.3.0
+- [x] APM Server version 7.3.0
+- [x] APM Search 7.3.0
+- [x] NGINX
+
+# **NOTES**
+- If you need Open Source version then change Elasticsearch and Kibana Images to elasticsearch-oss and kibana-oss respectively.
+- Kibana is being served behind Nginx Proxy so you can secure access of kibana for your purpose.
+
+# **COMING UP DOCKER APPLICATION PACKAGE FOR SWARM**
+
+## **Requirements**
+- [x] Docker 18.05
+- [x] Docker-compose 1.21
+
+### **Start Stack in Daemon Mode**
+```
+docker-compose up -d
+```
+
+### **Check status of docker-compose cluster**
+```
+docker-compose ps -a
+```
+![](images/dockerps.png)
+
+
+### **Stop Compose Stack**
+```
+docker-compose down
+```
+
+### **Cluster Node Info**
+```
+curl http://localhost:9200/_nodes?pretty=true
+```
+
+### **Access Kibana**
+```
+http://localhost:5601
+```
+
+### **Accessing Kibana through Nginx**
+```
+http://localhost:8080
+```
+
+### **Access Elasticsearch**
+```
+http://localhost:9200
+```
+
+# **Resources**
+* [Hands on Elasticsearch](https://medium.com/@maxy_ermayank/hands-on-elasticsearch-8fa59d8aebfc)
+* [Elasticsearch Resources](https://medium.com/@maxy_ermayank/elasticsearch-resources-27d24f01c1dc)
+* [Open Distro Elasticsearch](https://medium.com/@maxy_ermayank/tl-dr-aws-open-distro-elasticsearch-fc642f0e592a)

--- a/docker/configs/nginx/nginx.conf
+++ b/docker/configs/nginx/nginx.conf
@@ -1,0 +1,30 @@
+upstream kibana {
+    server kibana:5601;
+}
+
+upstream elasticsearch {
+    server elasticsearch1:9200;
+    server elasticsearch2:9201;
+    server elasticsearch3:9202;
+}
+
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://kibana;
+        proxy_redirect off;
+    }
+    
+    location /elasticsearch {
+        proxy_pass            http://elasticsearch/;
+        proxy_read_timeout    90;
+        proxy_connect_timeout 90;
+        proxy_set_header      Host $host;
+        proxy_set_header      X-Real-IP $remote_addr;
+        proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header      Connection "Keep-Alive";
+        proxy_set_header      Proxy-Connection "Keep-Alive";
+        proxy_set_header      Proxy "";
+    }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,327 @@
+version: "3.7"
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.0
+    container_name: elasticsearch1
+    environment:
+      - node.name=elasticsearch1
+      - cluster.name=docker-cluster
+      - cluster.initial_master_nodes=elasticsearch1
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms256M -Xmx256M"
+      - http.cors.enabled=true
+      - http.cors.allow-origin=*
+      - network.host=_eth0_
+    ulimits:
+      nproc: 65535
+      memlock:
+        soft: -1
+        hard: -1
+    cap_add:
+      - ALL
+    # privileged: true
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+      resources:
+        limits:
+          cpus: "1"
+          memory: 256M
+        reservations:
+          cpus: "1"
+          memory: 256M
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 10s
+    volumes:
+      - type: volume
+        source: logs
+        target: /var/log
+      - type: volume
+        source: esdata1
+        target: /usr/share/elasticsearch/data
+    networks:
+      - elastic
+      - ingress
+    ports:
+      - 9200:9200
+      - 9300:9300
+
+  elasticsearch2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.0
+    container_name: elasticsearch2
+    environment:
+      - node.name=elasticsearch2
+      - cluster.name=docker-cluster
+      - cluster.initial_master_nodes=elasticsearch1
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms256M -Xmx256M"
+      - "discovery.zen.ping.unicast.hosts=elasticsearch1"
+      - http.cors.enabled=true
+      - http.cors.allow-origin=*
+      - network.host=_eth0_
+    ulimits:
+      nproc: 65535
+      memlock:
+        soft: -1
+        hard: -1
+    cap_add:
+      - ALL
+    # privileged: true
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+      resources:
+        limits:
+          cpus: "1"
+          memory: 256M
+        reservations:
+          cpus: "1"
+          memory: 256M
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 10s
+    volumes:
+      - type: volume
+        source: logs
+        target: /var/log
+      - type: volume
+        source: esdata2
+        target: /usr/share/elasticsearch/data
+    networks:
+      - elastic
+      - ingress
+    ports:
+      - 9201:9200
+
+  elasticsearch3:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.0
+    container_name: elasticsearch3
+    environment:
+      - node.name=elasticsearch3
+      - cluster.name=docker-cluster
+      - cluster.initial_master_nodes=elasticsearch1
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms256M -Xmx256M"
+      - "discovery.zen.ping.unicast.hosts=elasticsearch1"
+      - http.cors.enabled=true
+      - http.cors.allow-origin=*
+      - network.host=_eth0_
+    ulimits:
+      nproc: 65535
+      memlock:
+        soft: -1
+        hard: -1
+    cap_add:
+      - ALL
+    # privileged: true
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+      resources:
+        limits:
+          cpus: "1"
+          memory: 256M
+        reservations:
+          cpus: "1"
+          memory: 256M
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 10s
+    volumes:
+      - type: volume
+        source: logs
+        target: /var/log
+      - type: volume
+        source: esdata3
+        target: /usr/share/elasticsearch/data
+    networks:
+      - elastic
+      - ingress
+    ports:
+      - 9202:9200
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.3.0
+    container_name: kibana
+    environment:
+      SERVER_NAME: localhost
+      ELASTICSEARCH_URL: http://elasticsearch1:9200/
+    ports:
+      - 5601:5601
+    volumes:
+      - type: volume
+        source: logs
+        target: /var/log
+    ulimits:
+      nproc: 65535
+      memlock:
+        soft: -1
+        hard: -1
+    cap_add:
+      - ALL
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+      resources:
+        limits:
+          cpus: "1"
+          memory: 256M
+        reservations:
+          cpus: "1"
+          memory: 256M
+      restart_policy:
+        condition: on-failure
+        delay: 30s
+        max_attempts: 3
+        window: 120s
+    networks:
+      - elastic
+      - ingress
+
+  auditbeat:
+    image: docker.elastic.co/beats/auditbeat:7.3.0
+    command: auditbeat -e -strict.perms=false
+    user: root
+    environment:
+      - setup.kibana.host=kibana:5601
+      - output.elasticsearch.hosts=["elasticsearch:9200"]
+    cap_add: ["AUDIT_CONTROL", "AUDIT_READ"]
+    pid: "host"
+    volumes:
+      #   - ${PWD}/configs/auditbeat.docker.yml:/usr/share/auditbeat/auditbeat.yml
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - elastic
+
+  metricbeat:
+    image: docker.elastic.co/beats/metricbeat:7.3.0
+    # command: --strict.perms=false
+    environment:
+      - setup.kibana.host=kibana:5601
+      - output.elasticsearch.hosts=["elasticsearch:9200"]
+    cap_add:
+      - AUDIT_CONTROL
+      - AUDIT_READ
+    volumes:
+      # - ${PWD}/configs/metricbeat.docker.yml:/usr/share/metricbeat/metricbeat.yml
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro
+      - /proc:/hostfs/proc:ro
+      - /:/hostfs:ro
+    networks:
+      - elastic
+
+  heartbeat:
+    image: docker.elastic.co/beats/heartbeat:7.3.0
+    command: --strict.perms=false
+    environment:
+      - setup.kibana.host=kibana:5601
+      - output.elasticsearch.hosts=["elasticsearch:9200"]
+    # volumes:
+    #   - ${PWD}/configs/heartbeat.docker.yml:/usr/share/heartbeat/heartbeat.yml
+    networks:
+      - elastic
+
+  packetbeat:
+    image: docker.elastic.co/beats/packetbeat:7.3.0
+    command: --strict.perms=false
+    environment:
+      - setup.kibana.host=kibana:5601
+      - output.elasticsearch.hosts=["elasticsearch:9200"]
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
+    # volumes:
+    #   - ${PWD}/configs/packetbeat.docker.yml:/usr/share/packetbeat/packetbeat.yml
+    networks:
+      - elastic
+
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:7.3.0
+    command: --strict.perms=false
+    environment:
+      - setup.kibana.host=kibana:5601
+      - output.elasticsearch.hosts=["elasticsearch:9200"]
+    ports:
+      - 9000:9000
+    volumes:
+      # - ${PWD}/configs/filebeat.docker.yml:/usr/share/filebeat/filebeat.yml
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - elastic
+
+  apmserver:
+    image: docker.elastic.co/apm/apm-server:7.3.0
+    command: --strict.perms=false
+    ports:
+      - 8200:8200
+      - 8201:8200
+    environment:
+      - apm-server.host=0.0.0.0
+      - setup.kibana.host=kibana:5601
+      - output.elasticsearch.hosts=["elasticsearch:9200"]
+    # volumes:
+    #   - ${PWD}/configs/apm-server.yml:/usr/share/apm-server/apm-server.yml
+    networks:
+      - elastic
+
+  app-search:
+    image: docker.elastic.co/app-search/app-search:7.3.0
+    ports:
+      - 3002:3002
+    environment:
+      secret_session_key: supersecretsessionkey
+      elasticsearch.host: http://elasticsearch1:9200/
+      allow_es_settings_modification: "true"
+    networks:
+      - elastic
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - 8081:80
+    volumes:
+      - ${PWD}/docker/configs/nginx/:/etc/nginx/conf.d/
+    command: /bin/bash -c "nginx -g 'daemon off;'"
+    ulimits:
+      nproc: 65535
+    networks:
+      - ingress
+
+volumes:
+  esdata1:
+  esdata2:
+  esdata3:
+  logs:
+
+networks:
+  elastic:
+  ingress:
+
+# configs:
+#   auditbeat_config:
+#     file: configs/auditbeat.docker.yml
+#   filebeat_config:
+#     file: configs/filebeat.docker.yml
+#   heartbeat_config:
+#     file: configs/heartbeat.docker.yml
+#   metricbeat_config:
+#     file: configs/metricbeat.docker.yml
+#   packetbeat_config:
+#     file: configs/packetbeat.docker.yml

--- a/mapping.json
+++ b/mapping.json
@@ -1,0 +1,16 @@
+{
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "genre": {
+            "type": "text"
+        },
+        "species": {
+            "type": "text"
+        },
+        "location": {
+            "type": "geo_point"
+        }
+    }
+}

--- a/scripts/init-elasticsearch.sh
+++ b/scripts/init-elasticsearch.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+SCRIPTS_DIR=$(dirname "$0")
+ROOT_DIR="${SCRIPTS_DIR}/.."
+
+function initIndices() {
+    # create index
+    curl -X PUT "localhost:9200/plants?pretty"
+
+    # create index mapping
+    curl -X PUT "localhost:9200/plants/_mapping?pretty" \
+        -H 'Content-Type: application/json' \
+        -d @${ROOT_DIR}/mapping.json
+}
+
+function run() {
+    docker-compose -f ${ROOT_DIR}/docker/docker-compose.yml up -d
+}
+
+function main() {
+    run
+
+    # wait for elasticsearch to start up
+    sleep 60
+
+    initIndices
+}
+
+main "$@"


### PR DESCRIPTION
## ¿Qué hace esta PR?
Esta PR añade Elasticsearch como el almacenamiento principal donde almacenar la información. Además se añade el esquema de datos del índice de ES en formato JSON.

En cuanto a Elasticsearch, se levanta un stack local incluyendo:
- [x] 3 Nodos de Elasticsearch 7.3.0, para almacenar la información
- [x] Kibana 7.3.0 para visualizar la información en formato dashboard (y más)
- [x] Audit Beat 7.3.0 para realizar auditoría del sistema
- [x] Metric Beat 7.3.0 para recopilar métricas del sistema
- [x] Heart Beat 7.3.0 para tener un uptime del sistema
- [x] Packet Beat 7.3.0 para tener una monitorización del tráfico de red
- [x] File Beat 7.3.0 para indexar ficheros en elasticsearch
- [x] APM Server 7.3.0 para poder hacer APM en la aplicación
- [x] App Search 7.3.0 para poder hacer búsquedas en la aplicación
- [x] NGINX como web proxy

Por otro lado, añade `Make` como wrapper para lanzar/destruir el stack.

## ¿Por qué es importante?
Porque crea el almacenamiento principal de la aplicación, que dada las necesidad de utilizar características de geoposición, consideramos que ES es el mejor candidato.

Además permitirá a cualquier desarrollador levantar la aplicación en local, utilizando Make `make start`, que usa `docker-compose` por debajo para levantar el stack, y `make destroy` para cargarse el stack.
